### PR TITLE
chore: stop using macos CI runners

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -33,7 +33,7 @@ jobs:
         
   publish_javascript:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: release
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
In the past, we had issues with ubuntu runners in certain situations and were forced to use macos, which is much more expensive. Those issues have now been resolved on the Azure/github side, so we can switch back to ubuntu to reduce costs.
